### PR TITLE
added startup check and additional option + docs

### DIFF
--- a/lib/Mojolicious/Plugin/SizeLimit.pm
+++ b/lib/Mojolicious/Plugin/SizeLimit.pm
@@ -67,7 +67,7 @@ Parameters:
     };
 
     if(defined($conf->{min_shared_size}) && $shared < $conf->{min_shared_size}) {
-        $app->log->info("max_process_size was not met during startup");
+        $app->log->info("min_shared_size was not met during startup");
         exit 1;
     };
 }

--- a/t/startup.t
+++ b/t/startup.t
@@ -20,5 +20,5 @@ my $t = Test::Mojo->new;
 my $shutdown_on_startup_occured = 0;
 Mojo::IOLoop->singleton->on("sizelimit_shutdown", sub { $shutdown_on_startup_occured = 1;  });
 plugin 'SizeLimit', max_process_size => 1, check_interval => 20, startup_check => 1, report_level => 'info';
-ok($shutdown_on_startup_occured, "ioloop is running");
+ok($shutdown_on_startup_occured, "shutdown occured as expected");
 done_testing();

--- a/t/startup.t
+++ b/t/startup.t
@@ -1,0 +1,24 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Mojo::IOLoop;
+use Mojolicious::Lite;
+use Test::Mojo;
+
+require Mojolicious::Plugin::SizeLimit;
+
+my ($total, $shared) = Mojolicious::Plugin::SizeLimit::check_size();
+
+unless (ok $total, "OS ($^O) is supported") {
+    done_testing();
+    exit 0;
+}
+
+my $stopped = 0;
+
+my $t = Test::Mojo->new;
+my $shutdown_on_startup_occured = 0;
+Mojo::IOLoop->singleton->on("sizelimit_shutdown", sub { $shutdown_on_startup_occured = 1;  });
+plugin 'SizeLimit', max_process_size => 1, check_interval => 20, startup_check => 1, report_level => 'info';
+ok($shutdown_on_startup_occured, "ioloop is running");
+done_testing();


### PR DESCRIPTION
The following Perl program was written. The `max_memory_size` will intentionally not be met in order to trigger the shut down of the process.

```perl
#!/usr/bin/perl
use lib qw(lib);
use Mojolicious::Lite;
use Mojolicious::Plugin::SizeLimit;
plugin 'Mojolicious::Plugin::SizeLimit', 
    { 
        max_process_size => (1024**2) * 0.01,
        startup_check    => 1,
    };
get '/' => sub {
  my $c = shift;
};
app->start;
```

Fixes #2 

Please consider merging #5 before this, in order for the tests to pass.
